### PR TITLE
Build windows wheels using appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,9 @@ matrix:
     fast_finish: true
 
 install:
+    # Fetch submodules
+    - git submodule update --init --recursive
+
     # Install miniconda
     - ps: .\\multibuild\\ci\\appveyor\\install.ps1
     - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PYTHON%\Library\bin;%PATH%
@@ -53,9 +56,6 @@ install:
     # Check that we have the expected version and architecture for Python
     - python --version
     - python -c "import struct; print(struct.calcsize('P') * 8)"
-
-    # Fetch submodules
-    - git submodule update --init --recursive
 
 build_script:
     # Install build requirements

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,6 @@ on_success:
   # Upload the generated wheel package to Rackspace
   # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
   # disable the ssl checks.
-  - cd %REPO_DIR%
   - pip install wheelhouse-uploader
-  - python -m wheelhouse_uploader upload
-    --no-ssl-check --local-folder=dist --no-update-index wheels
+  - "python -m wheelhouse_uploader upload
+    --no-ssl-check --local-folder=%REPO_DIR%\\dist --no-update-index wheels"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,88 @@
+environment:
+  global:
+    REPO_DIR: astropy
+    PACKAGE_NAME: astropy
+    BUILD_COMMIT: v1.2.1
+    BUILD_DEPENDS: "numpy>=1.7.0 cython jinja2"
+    TEST_DEPENDS: "numpy>=1.7.0"
+    WHEELHOUSE_UPLOADER_USERNAME: travis-worker
+    WHEELHOUSE_UPLOADER_SECRET:
+        secure:
+            9s0gdDGnNnTt7hvyNpn0/ZzOMGPdwPp2SewFTfGzYk7uI+rdAN9rFq2D1gAP4NQh
+
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C %APPVEYOR_BUILD_FOLDER%\\multibuild\\ci\\appveyor\\windows_sdk.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Miniconda"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda3"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Miniconda3-x64"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda35"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Miniconda35-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+
+
+# We always use a 64-bit machine, but can build x86 distributions
+# with the TARGET_ARCH variable.
+platform:
+    - x64
+
+matrix:
+    fast_finish: true
+
+install:
+    # Install miniconda
+    - ps: .\\multibuild\\ci\\appveyor\\install.ps1
+    - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PYTHON%\Library\bin;%PATH%
+    - conda info
+
+    # Check that we have the expected version and architecture for Python
+    - python --version
+    - python -c "import struct; print(struct.calcsize('P') * 8)"
+
+    # Fetch submodules
+    - git submodule update --init --recursive
+
+build_script:
+    # Install build requirements
+    - conda install --yes %BUILD_DEPENDS%
+
+    # build wheel:
+    - cd %REPO_DIR%
+    - git checkout %BUILD_COMMIT%
+    - "%CMD_IN_ENV% python setup.py bdist_wheel"
+
+test_script:
+    # create test env
+    - conda create --yes -n test_env python=%PYTHON_VERSION% %TEST_DEPENDS%
+    - activate test_env
+
+    # install from wheel
+    - pip install --no-index --find-links dist/ %PACKAGE_NAME%
+
+    - "%CMD_IN_ENV% python setup.py test"
+
+artifacts:
+    - path: "%REPO_DIR%\\dist\\*"
+
+on_success:
+  # Upload the generated wheel package to Rackspace
+  # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
+  # disable the ssl checks.
+  - pip install wheelhouse-uploader
+  - python -m wheelhouse_uploader upload
+    --no-ssl-check --local-folder=dist --no-update-index wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,6 +83,7 @@ on_success:
   # Upload the generated wheel package to Rackspace
   # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
   # disable the ssl checks.
+  - cd %REPO_DIR%
   - pip install wheelhouse-uploader
   - python -m wheelhouse_uploader upload
     --no-ssl-check --local-folder=dist --no-update-index wheels


### PR DESCRIPTION
This is very similar to MacPython/pytables-wheels#2

It builds a wheel in a conda enviroments, installs the wheel in a new env and runs tests.

Fixes astropy/astropy#802

