### PR TITLE
Build astropy v1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
+        - PLAT=x86_64
         - NP_BUILD_DEP=numpy==1.11.3
         - NP_TEST_DEP=numpy==1.11.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR=astropy
-      - BUILD_COMMIT=v1.2.1
+      - BUILD_COMMIT=v1.3
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.7.1"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     REPO_DIR: astropy
     PACKAGE_NAME: astropy
-    BUILD_COMMIT: v1.2.1
+    BUILD_COMMIT: v1.3
     BUILD_DEPENDS: "numpy>=1.7.0 cython jinja2"
     TEST_DEPENDS: "numpy>=1.7.0"
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,12 +34,12 @@ environment:
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Miniconda36"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
+    # - PYTHON: "C:\\Miniconda36"
+    #   PYTHON_VERSION: "3.6"
+    #   PYTHON_ARCH: "32"
+    # - PYTHON: "C:\\Miniconda36-x64"
+    #   PYTHON_VERSION: "3.6"
+    #   PYTHON_ARCH: "64"
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,8 @@ test_script:
 
     # run test from installed wheel.
     - cd ..
-    - python -c "import sys; import astropy; sys.exit(astropy.test(remote_data='none'))"
+    # The test try to run cython/msvc so CMD_IN_ENV is needed
+    - "%CMD_IN_ENV% python -c \"import astropy; astropy.test(remote_data='none')\""
 
 artifacts:
     - path: "%REPO_DIR%\\dist\\*"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,9 @@ test_script:
     # install from wheel
     - pip install --no-index --find-links dist/ %PACKAGE_NAME%
 
-    - "%CMD_IN_ENV% python setup.py test"
+    # run test from installed wheel.
+    - cd ..
+    - python -c "import sys; import astropy; sys.exit(astropy.test(remote_data='none'))"
 
 artifacts:
     - path: "%REPO_DIR%\\dist\\*"

--- a/config.sh
+++ b/config.sh
@@ -14,7 +14,7 @@ function pip_opts {
     else
         local suffix=manylinux
     fi
-    echo "--find-links https://nipy.bic.berkeley.edu/$suffix"
+    echo "--only-binary matplotlib --find-links https://nipy.bic.berkeley.edu/$suffix"
 }
 
 function run_tests {

--- a/config.sh
+++ b/config.sh
@@ -20,5 +20,5 @@ function pip_opts {
 function run_tests {
     # Runs tests on installed distribution from an empty directory
     python --version
-    python -c 'import sys; import astropy; sys.exit(astropy.test())'
+    python -c "import sys; import astropy; sys.exit(astropy.test(remote_data='none'))"
 }


### PR DESCRIPTION
Build astropy v1.3 on appveyor and travis.

I have disabled the appveyor (windows) builds for python 3.6. Although installing python 3.6 from conda is possible (with a work-around) the tests fail ([appveyor build](https://ci.appveyor.com/project/tomkooij/astropy-wheels/build/1.0.16))

Even after merging this will **not** upload the windows wheels to the wheelhouse. The provided password is copied from the matthew-brett appveyor account (from MacPython/cython-wheels and pytables-wheels). The password needs to be reencrypted using the MacPython appveyor account. 

Closes #3 