### PR TITLE
Build v1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR=astropy
-      - BUILD_COMMIT=v1.3
+      - BUILD_COMMIT=v1.3.1
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.7.1"
@@ -69,7 +69,7 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - PLAT=x86_64
+        - PLAT=i686
         - NP_BUILD_DEP=numpy==1.11.3
         - NP_TEST_DEP=numpy==1.11.3
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.4
+        - NP_BUILD_DEP=numpy==1.8.1
         - NP_TEST_DEP=numpy==1.8.1
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.4
+        - NP_BUILD_DEP=numpy==1.8.1
         - NP_TEST_DEP=numpy==1.8.1
         - PLAT=i686
     - os: linux
@@ -79,6 +81,7 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.4
+        - NP_BUILD_DEP=numpy==1.8.1
         - NP_TEST_DEP=numpy==1.8.1
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ env:
       - BUILD_COMMIT=v1.3.1
       - PLAT=x86_64
       - UNICODE_WIDTH=32
-      - NP_BUILD_DEP="numpy==1.8.2"
-      - NP_TEST_DEP="numpy==1.8.2"
+      - NP_BUILD_DEP="numpy==1.8.1"
+      - NP_TEST_DEP="numpy==1.8.1"
       - GEN_DEPS="pyyaml psutil scipy h5py matplotlib beautifulsoup4"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with
@@ -44,13 +44,9 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.4
-        - NP_BUILD_DEP=numpy==1.8.1
-        - NP_TEST_DEP=numpy==1.8.1
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.4
-        - NP_BUILD_DEP=numpy==1.8.1
-        - NP_TEST_DEP=numpy==1.8.1
         - PLAT=i686
     - os: linux
       env:
@@ -81,8 +77,6 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.4
-        - NP_BUILD_DEP=numpy==1.8.1
-        - NP_TEST_DEP=numpy==1.8.1
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ env:
       - BUILD_COMMIT=v1.3.1
       - PLAT=x86_64
       - UNICODE_WIDTH=32
-      - NP_BUILD_DEP="numpy==1.11.3"
-      - NP_TEST_DEP="numpy==1.11.3"
+      - NP_BUILD_DEP="numpy==1.8.2"
+      - NP_TEST_DEP="numpy==1.8.2"
       - GEN_DEPS="pyyaml psutil scipy h5py matplotlib beautifulsoup4"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ env:
       - BUILD_COMMIT=v1.3.1
       - PLAT=x86_64
       - UNICODE_WIDTH=32
-      - NP_BUILD_DEP="numpy==1.7.1"
-      - NP_TEST_DEP="numpy==1.7.1"
+      - NP_BUILD_DEP="numpy==1.11.3"
+      - NP_TEST_DEP="numpy==1.11.3"
       - GEN_DEPS="pyyaml psutil scipy h5py matplotlib beautifulsoup4"
       - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
       # Following generated with

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     REPO_DIR: astropy
     PACKAGE_NAME: astropy
-    BUILD_COMMIT: v1.3
+    BUILD_COMMIT: v1.3.1
     BUILD_DEPENDS: "numpy>=1.7.0 cython jinja2"
     TEST_DEPENDS: "numpy>=1.7.0"
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker
@@ -34,12 +34,12 @@ environment:
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
-    # - PYTHON: "C:\\Miniconda36"
-    #   PYTHON_VERSION: "3.6"
-    #   PYTHON_ARCH: "32"
-    # - PYTHON: "C:\\Miniconda36-x64"
-    #   PYTHON_VERSION: "3.6"
-    #   PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda36"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Miniconda36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
 
 
 # We always use a 64-bit machine, but can build x86 distributions


### PR DESCRIPTION
Enable Linux x64 build for Python 3.6.
Enable Windows builds for Python 3.6.

Appveyor passes on my fork, but I had not enabled Travis CI on my fork, so I haven't tested the Linux/OSX builds. I re-enabled the x64 (i686) build for python 3.6 on Linux.