### PR TITLE
Adding patch for h5py version dependent error message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,44 +32,44 @@ matrix:
       env:
         - MB_PYTHON_VERSION=2.7
         - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
+#    - os: linux
+#      env:
+#        - MB_PYTHON_VERSION=2.7
+#        - PLAT=i686
+#    - os: linux
+#      env:
+#        - MB_PYTHON_VERSION=2.7
+#        - PLAT=i686
+#        - UNICODE_WIDTH=16
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
+#    - os: linux
+#      env:
+#        - MB_PYTHON_VERSION=3.4
+#        - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP=numpy==1.9.3
         - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+#    - os: linux
+#      env:
+#        - MB_PYTHON_VERSION=3.5
+#        - PLAT=i686
+#        - NP_BUILD_DEP=numpy==1.9.3
+#        - NP_TEST_DEP=numpy==1.9.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.11.3
         - NP_TEST_DEP=numpy==1.11.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+#    - os: linux
+#      env:
+#        - MB_PYTHON_VERSION=3.6
+#        - PLAT=i686
+#        - NP_BUILD_DEP=numpy==1.11.3
+#        - NP_TEST_DEP=numpy==1.11.3
     - os: osx
       language: generic
       env: MB_PYTHON_VERSION=2.7

--- a/config.sh
+++ b/config.sh
@@ -19,6 +19,13 @@ function pip_opts {
 
 function run_tests {
     # Runs tests on installed distribution from an empty directory
+    ASTROPY_INSTALL_DIR=$(dirname $(python -c 'import astropy; print(astropy.__file__)'))
+
+    # Patch the h5py test file to fix test for 2.7.1 error message change
+    local patch_file=$(abspath ../patches/h5py_2.7.1.patch)
+    (cd $ASTROPY_INSTALL_DIR && patch -p0 < $patch_file)
+
+    # Runs tests on installed distribution from an empty directory
     python --version
     python -c "import sys; import astropy; sys.exit(astropy.test(remote_data='none'))"
 }

--- a/patches/h5py_2.7.1.patch
+++ b/patches/h5py_2.7.1.patch
@@ -1,0 +1,12 @@
+--- astropy/io/misc/tests/test_hdf5.py.old
++++ astropy/io/misc/tests/test_hdf5.py
+@@ -494,7 +494,8 @@ def test_metadata_very_large_fails_compatibility_mode(tmpdir):
+
+     assert str(w[1].message).startswith(
+         "Attributes could not be written to the output HDF5 "
+-        "file: Unable to create attribute (Object header message is too large)")
++        "file: Unable to create attribute ")
++    assert "bject header message is too large" in str(w[1].message)
+
+
+ @pytest.mark.skipif('not HAS_H5PY')

--- a/patches/h5py_2.7.1.patch
+++ b/patches/h5py_2.7.1.patch
@@ -1,5 +1,5 @@
---- astropy/io/misc/tests/test_hdf5.py.old
-+++ astropy/io/misc/tests/test_hdf5.py
+--- io/misc/tests/test_hdf5.py.old
++++ io/misc/tests/test_hdf5.py
 @@ -494,7 +494,8 @@ def test_metadata_very_large_fails_compatibility_mode(tmpdir):
 
      assert str(w[1].message).startswith(

--- a/patches/h5py_2.7.1.patch
+++ b/patches/h5py_2.7.1.patch
@@ -1,12 +1,12 @@
 --- io/misc/tests/test_hdf5.py.old
 +++ io/misc/tests/test_hdf5.py
-@@ -494,7 +494,8 @@ def test_metadata_very_large_fails_compatibility_mode(tmpdir):
-
-     assert str(w[1].message).startswith(
+@@ -413,7 +413,8 @@ def test_metadata_too_large(tmpdir):
+     assert len(w) == 1
+     assert str(w[0].message).startswith(
          "Attributes could not be written to the output HDF5 "
 -        "file: Unable to create attribute (Object header message is too large)")
 +        "file: Unable to create attribute ")
-+    assert "bject header message is too large" in str(w[1].message)
++    assert "bject header message is too large" in str(w[0].message)
 
 
  @pytest.mark.skipif('not HAS_H5PY')


### PR DESCRIPTION
patch is to be removed when astropy 2.0.3 is out

This patch is the equivalent of https://github.com/astropy/astropy/pull/6535, but we apply now so the wheels for the 2.0.2 release can be made even when the latest h5py release is used during the testing.

