### PR TITLE
Try installing tzdata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ matrix:
 
 
 before_install:
+    # tzdata is included to ensure system leap seconds are up to date.
+    - sudo apt-get install tzdata
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython jinja2 wheel"
     - TEST_DEPENDS="$NP_TEST_DEP $GEN_DEPS"
     - source multibuild/common_utils.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
       # Following generated with
       # travis encrypt -r MacPython/astropy-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
       - secure:
-          "MNKyBWOzu7JAUmC0Y+JhPKfytXxY/ADRmUIMEWZV977FLZPgYctqd+lqel2QIFgdHDO1CIdTSymOOFZckM9ICUXg9Ta+8oBjSvAVWO1ahDcToRM2DLq66fKg+NKimd2OfK7x597h/QmUSl4k8XyvyyXgl5jOiLg/EJxNE2r83IA="
+          "MNKyBWOzu7JAUmC0Y+JhPKfytXxY/ADRmUIMEWZV977FLZPgYctqd+lqel2QIFgdHDO1CIdTSymOOFZckM9ICUXg9Ta+8oBjSvAVWO1ahDcToRM2DLq66fKg+NKimdOfK7x597h/QmUSl4k8XyvyyXgl5jOiLg/EJxNE2r83IA="
       # Get extra wheels from Rackspace container
       - MANYLINUX_URL=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com
 
@@ -85,7 +85,9 @@ matrix:
 
 before_install:
     # tzdata is included to ensure system leap seconds are up to date.
-    - sudo apt-get install tzdata
+    - if [[ $TRAVIS_OS_NAME == linux ]]; then
+          sudo apt-get install tzdata;
+      fi
     - BUILD_DEPENDS="$NP_BUILD_DEP Cython jinja2 wheel"
     - TEST_DEPENDS="$NP_TEST_DEP $GEN_DEPS"
     - source multibuild/common_utils.sh


### PR DESCRIPTION
This should make sure we can remove the patched over test from astropy, yet won't run into leapsecond related issues for the wheels.

Based on https://github.com/astropy/astropy/pull/9720#issuecomment-561444766

The only part I wasn't sure about whether the standard apt installs from the `addons` section happens before or after the docker is started, so to make sure we have the package I simply put it in `before_install`. Alternatively, if it's also needed for appveyor, we could put it into `config.sh`.