### PR TITLE
Build wheels for v4.1rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
     - if [[ $TRAVIS_OS_NAME == linux ]]; then
           sudo apt-get install tzdata;
       fi
-    - BUILD_DEPENDS="$NP_BUILD_DEP Cython jinja2 wheel"
+    - BUILD_DEPENDS="$NP_BUILD_DEP Cython jinja2 wheel extension-helpers setuptools_scm"
     - TEST_DEPENDS="$NP_TEST_DEP $GEN_DEPS"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
       - REPO_DIR=astropy
-      - BUILD_COMMIT=v4.0.1.post1
+      - BUILD_COMMIT=v4.1rc1
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.16.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
   global:
     REPO_DIR: astropy
     PACKAGE_NAME: astropy
-    BUILD_COMMIT: v4.0.1.post1
+    BUILD_COMMIT: v4.1rc1
     NP_BUILD_DEP: "numpy==1.16.5"
     NP_TEST_DEP: "numpy==1.16.5"
     OTHER_BUILD_DEP: "cython jinja2 extension-helpers setuptools_scm"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
     BUILD_COMMIT: v4.0.1.post1
     NP_BUILD_DEP: "numpy==1.16.5"
     NP_TEST_DEP: "numpy==1.16.5"
-    OTHER_BUILD_DEP: "cython jinja2"
+    OTHER_BUILD_DEP: "cython jinja2 extension-helpers setuptools_scm"
     OTHER_TEST_DEP: "pytest-doctestplus==0.4.0 pytest-astropy"
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker
     WHEELHOUSE_UPLOADER_SECRET:


### PR DESCRIPTION
For now this is a work in progress, just to check that the wheel building machinery works fine with the latest commit on the v4.1.x branch.

Once the wheels pass here and any issues have been fixed, we can continue the astropy release procedure, and once we get to the wheels step this PR can be updated to remove the TMP commit below and change the commit to build to the v4.1rc1 tag.